### PR TITLE
Add LLVM 13

### DIFF
--- a/13.Dockerfile
+++ b/13.Dockerfile
@@ -1,0 +1,24 @@
+FROM debian:bullseye
+
+# Install dependencies
+RUN apt-get -qq update && \
+    apt-get install -qqy --no-install-recommends \
+        ca-certificates \
+        autoconf automake cmake dpkg-dev file git make patch \
+        libc-dev libc++-dev libgcc-10-dev libstdc++-10-dev  \
+        dirmngr gnupg2 lbzip2 wget xz-utils libtinfo5 && \
+    rm -rf /var/lib/apt/lists/*
+
+# Signing keys
+ENV GPG_KEYS 09C4E7007CB2EFFB A2C794A986419D8A B4468DF4E95C63DC D23DD2C20DD88BA2 8F0871F202119294 0FC3042E345AD05D
+
+# Retrieve keys
+RUN gpg --batch --keyserver keyserver.ubuntu.com --recv-keys $GPG_KEYS
+
+# Version info
+ENV LLVM_RELEASE 13
+ENV LLVM_VERSION 13.0.0
+
+# Install Clang and LLVM
+COPY install.sh .
+RUN ./install.sh

--- a/install.sh
+++ b/install.sh
@@ -88,6 +88,10 @@ case "${ARCH}:${LLVM_VERSION}" in
   MIRROR="github"
   PLATFORM="linux-gnu-ubuntu-20.04"
   ;;
+"x86_64:13.0."*)
+  MIRROR="github"
+  PLATFORM="linux-gnu-ubuntu-20.04"
+  ;;
 esac
 
 case "${MIRROR}" in


### PR DESCRIPTION
This PR adds a Dockerfile for LLVM 13. I had to change the keyserver used as the old one is deprecated.﻿
