### PR TITLE
Fix link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Tags and corresponding docker files:
 - `12`: [/12.Dockerfile](https://github.com/silkeh/docker-clang/blob/master/12.Dockerfile)
 - `13`: [/13.Dockerfile](https://github.com/silkeh/docker-clang/blob/master/13.Dockerfile)
 - `14`: [/14.Dockerfile](https://github.com/silkeh/docker-clang/blob/master/14.Dockerfile)
-- `latest`: [/Dockerfile](https://github.com/silkeh/docker-clang/blob/master/Dockerfile)
+- `latest`: [/Dockerfile](https://github.com/silkeh/docker-clang/blob/master/latest.Dockerfile)
 - `dev`: [/dev.Dockerfile](https://github.com/silkeh/docker-clang/blob/master/dev.Dockerfile)
 
 The `dev` tag contains a nightly build of the unstable branch from <https://apt.llvm.org/>.


### PR DESCRIPTION
Quick fix to the `latest` link in the readme