### PR TITLE
Fix case warnings

### DIFF
--- a/templates/debian.Dockerfile
+++ b/templates/debian.Dockerfile
@@ -21,10 +21,10 @@ RUN echo "deb {repo_url} {repo_distribution} {repo_component}" \
     ln -sf clang++ /usr/bin/g++ && \
     rm -rf /var/lib/apt/lists/*
 
-FROM intermediate as test
+FROM intermediate AS test
 
 COPY tests /tests
 
 RUN /tests/run.sh {version}
 
-FROM intermediate as final
+FROM intermediate AS final


### PR DESCRIPTION
```
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 24)                                                                                                      0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 30)  
```